### PR TITLE
Update copyright notice in LICENSE.md

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 # MIT License
 
-Copyright (c) 2025 [homeassistant-apps][github-org]
+Copyright (c) 2025 Unofficial Home Assistant Apps (Add-ons)
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -19,5 +19,3 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
-
-[github-org]: https://github.com/homeassistant-apps


### PR DESCRIPTION
# Proposed Changes

The link made the license shield broken.

See: https://img.shields.io/github/license/homeassistant-apps/repository.svg

## Related Issues
